### PR TITLE
Fix version literal range

### DIFF
--- a/lib/JSON/Marshal.pm
+++ b/lib/JSON/Marshal.pm
@@ -59,7 +59,7 @@ use JSON::Name;
 
 module JSON::Marshal:ver<0.0.12>:auth<github:jonathanstowe> {
 
-    use JSON::Fast:ver(v0.4..*);
+    use JSON::Fast:ver(v0.4+);
 
 
     role CustomMarshaller {


### PR DESCRIPTION
`v0.4..*` gets parsed as a version `0.4.*`

This commit exposed the problem:
https://github.com/rakudo/rakudo/commit/247fc6499d22ad30a09345838dca4e3bf0f5e42d

Before rakudo did not even treat it like a version, it made a smart match ala `Version ~~ Str`. So while it was coincidentally working it would not have actually filtered the way one might expect.