### PR TITLE
Clarify what is skipped and what is included into the final JSON

### DIFF
--- a/lib/JSON/Marshal.rakumod
+++ b/lib/JSON/Marshal.rakumod
@@ -167,16 +167,10 @@ module JSON::Marshal:ver<0.0.23>:auth<github:jonathanstowe> {
         $value;
     }
 
-    multi sub _marshal(Associative:U) {
-        Nil;
-    }
     multi sub _marshal(Associative:D \obj --> Hash:D) {
         obj.kv.map(-> $key, $value { $key => _marshal($value) }).Hash
     }
 
-    multi sub _marshal(Positional:U --> Nil) {
-        Nil;
-    }
     multi sub _marshal(Positional:D \obj --> Positional:D) {
         obj.map({ _marshal($_) }).eager
     }

--- a/lib/JSON/Marshal.rakumod
+++ b/lib/JSON/Marshal.rakumod
@@ -189,7 +189,7 @@ module JSON::Marshal:ver<0.0.23>:auth<github:jonathanstowe> {
             if %local-attrs{$attr.name}:exists && !(%local-attrs{$attr.name} === $attr.package ) {
                 next;
             }
-            if $attr.has_accessor {
+            if $attr.has_accessor || $attr.is_built || $attr ~~ JSON::OptIn::OptedInAttribute {
                 my $accessor-name = $attr.name.substr(2); # lose the sigil
                 my $name = do if $attr ~~ JSON::Name::NamedAttribute {
                     $attr.json-name;

--- a/t/020-marshal.t
+++ b/t/020-marshal.t
@@ -7,6 +7,8 @@ use Test;
 use JSON::Marshal;
 use JSON::Fast;
 
+plan 12;
+
 class Inner {
     has %.hash = A => 1, B => 2;
     has Rat $.rat = 4.2;
@@ -18,6 +20,7 @@ class Outer {
     has Int  $.int = 42;
     has Inner $.inner = Inner.new;
     has $!private = 'private';
+    has Real $!half-priv is built = 42;
 }
 
 my $outer = Outer.new;
@@ -33,6 +36,7 @@ is %json<bool>, $outer.bool, "bool right";
 is %json<string>, $outer.string, "string right";
 is %json<int>, $outer.int, "int right";
 is %json<str-array>, $outer.str-array, "arrays are the same";
+is %json<half-priv>, 42, "is built attribute is included";
 is %json<inner><rat>, $outer.inner.rat, "inner class rat the same";
 is %json<inner><hash><A>, $outer.inner.hash<A>, "inner hash 1";
 is %json<inner><hash><B>, $outer.inner.hash<B>, "inner hash 2";

--- a/t/050-skip-null.t
+++ b/t/050-skip-null.t
@@ -6,6 +6,8 @@ use Test;
 use JSON::Marshal;
 use JSON::Fast;
 
+plan 15;
+
 # test default global behaviour
 class SkipTestClassOne {
     has Str $.id;
@@ -45,6 +47,16 @@ nok $out<leave-blank>.defined, "and it isn't defined";
 is $out<rev>, "bar", "one with the trait but with value is there";
 ok $out<empty-hash>:exists, "the empty hash is there";
 nok $out<skip-hash>:exists, "the skipped one isn't there";
+
+class NestedStruct {
+    has SkipTestClassOne:D $.stc1 .= new;
+    has SkipTestClassTwo:D $.stc2 .= new;
+}
+
+lives-ok
+    { $res-default = marshal(NestedStruct.new, :skip-null, :sorted-keys, :!pretty) },
+    "skip-null with a deep struct";
+is $res-default, '{"stc1":{},"stc2":{}}', "no empty keys are included";
 
 done-testing;
 # vim: expandtab shiftwidth=4 ft=raku

--- a/t/140-opt-in.t
+++ b/t/140-opt-in.t
@@ -6,6 +6,8 @@ use JSON::Name;
 use JSON::OptIn;
 use JSON::Fast;
 
+plan 11;
+
 class TestOptin {
     has Str $.secret = 'secret';
     has Str $.public                is json  = 'public';
@@ -15,6 +17,8 @@ class TestOptin {
     has DateTime $.marshalled       is marshalled-by('Str') = DateTime.now;
     has DateTime $.marshalled-sub   is marshalled-by(-> $v { $v.Str }) = DateTime.now;
     has Str      $.named            is json-name('zubzub') = 'named';
+    has Real     $!half-priv        is json = 42;
+    has Real     $!priv-built       is built = 13;
 }
 
 my Str $json;
@@ -24,13 +28,15 @@ lives-ok { $json = marshal(TestOptin.new, :opt-in) }, "marshal() with opt-in";
 my %data = from-json($json);
 
 is %data<public>, 'public', "explicitly opted in";
-ok !(%data<secret>:exists), "not opted-in at all";
-ok !(%data<skipped>:exists), "skipped";
-ok !(%data<null>:exists), "skip-null";
+ok %data<secret>:!exists, "not opted-in at all";
+ok %data<skipped>:!exists, "skipped";
+ok %data<null>:!exists, "skip-null";
+ok %data<priv-built>:!exists, "is built but not opted-in";
 is %data<nullable>, 'nullable', 'skip-null with value';
 ok %data<marshalled>:exists, "marshalled-by implicit opt-in (method)";
 ok %data<marshalled-sub>:exists, "marshalled-by implicit opt-in (sub)";
 is %data<zubzub>, 'named', 'json-name implicit opt-in';
+is %data<half-priv>, 42, 'opted-in private';
 
 
 done-testing;


### PR DESCRIPTION
Previously, `:skip-null` was only respected for the top-level object. Attributes of non-Cool type was then serialized without the adverb applied resulting in `"key": null` entries in the output JSON.

The fix might also have minor positive impact on performance of non-object candidates as less arguments are passed around.